### PR TITLE
Fixed broken remove link img in app/views/admin/text_assets/index.html.haml 

### DIFF
--- a/app/views/admin/text_assets/index.html.haml
+++ b/app/views/admin/text_assets/index.html.haml
@@ -46,7 +46,7 @@
             = image("sns/#{model_symbol}", :alt => "#{model_name}-icon", :title => text_asset.url)
             %span= link_to(text_asset.name, send("edit_admin_#{model_symbol}_path", :id => text_asset), :title => text_asset.url)
           %td.remove
-            = link_to image('remove', :alt => "Remove #{model_name}"), send("remove_admin_#{model_symbol}_path", :id => text_asset)
+            = link_to t('remove'), send("remove_admin_#{model_symbol}_path", :id => text_asset)
     - else
       %tr
         %td.note{:colspan => 2}== No #{plural_model_name}


### PR DESCRIPTION
There was a broken image on link in app/views/admin/text_assets/index.html.haml 
The old remove link pngs were removed in Radiant, long long ago; updated the link to reflect modern styling.
Those starting new projects will no longer have the public/admin/remove.png and will get a missing img display in their browsers.

See Diff for details..
